### PR TITLE
Direct message users who committed

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotification.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotification.java
@@ -122,4 +122,9 @@ public interface SlackNotification {
     public abstract void setShowFailureReason(boolean showFailureReason);
 
 	public abstract void setMentionWhoTriggeredEnabled(boolean mentionWhoTriggeredEnabled);
+
+	public abstract void setSendDefaultChannel(boolean sendDefaultChannel);
+
+	public abstract void setSendUsers(boolean sendUsers);
+
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
@@ -81,6 +81,7 @@ public class SlackNotificationListener extends BuildServerAdapter {
         slackNotification.setShowFailureReason(myMainSettings.getShowFailureReason() == null ? SlackNotificationContentConfig.DEFAULT_SHOW_FAILURE_REASON : myMainSettings.getShowFailureReason());
         slackNotification.setMaxCommitsToDisplay(myMainSettings.getMaxCommitsToDisplay());
         slackNotification.setMentionChannelEnabled(slackNotificationConfig.getMentionChannelEnabled());
+        slackNotification.setSendDefaultChannel(slackNotificationConfig.getSendDefaultChannel());
 		slackNotification.setMentionSlackUserEnabled(slackNotificationConfig.getMentionSlackUserEnabled());
 		slackNotification.setMentionWhoTriggeredEnabled(slackNotificationConfig.isMentionWhoTriggeredEnabled());
 		slackNotification.setMentionHereEnabled(slackNotificationConfig.getMentionHereEnabled());

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
@@ -82,6 +82,7 @@ public class SlackNotificationListener extends BuildServerAdapter {
         slackNotification.setMaxCommitsToDisplay(myMainSettings.getMaxCommitsToDisplay());
         slackNotification.setMentionChannelEnabled(slackNotificationConfig.getMentionChannelEnabled());
         slackNotification.setSendDefaultChannel(slackNotificationConfig.getSendDefaultChannel());
+        slackNotification.setSendUsers(slackNotificationConfig.getSendUsers());
 		slackNotification.setMentionSlackUserEnabled(slackNotificationConfig.getMentionSlackUserEnabled());
 		slackNotification.setMentionWhoTriggeredEnabled(slackNotificationConfig.isMentionWhoTriggeredEnabled());
 		slackNotification.setMentionHereEnabled(slackNotificationConfig.getMentionHereEnabled());

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/PayloadContentCommits.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/PayloadContentCommits.java
@@ -28,6 +28,7 @@ public class PayloadContentCommits {
             String slackUserId = null;
             if (!committers.isEmpty()) {
                 SUser committer = committers.iterator().next();
+                //Gets slackUserID from teamcity
                 slackUserId = committer.getPropertyValue(SlackNotificator.USERID_KEY);
                 Loggers.ACTIVITIES.debug("Resolved committer " + change.getUserName() + " to Slack User " + slackUserId);
             }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/SlackNotificationPayloadContent.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/SlackNotificationPayloadContent.java
@@ -338,7 +338,6 @@ public class SlackNotificationPayloadContent {
 
 
 
-
     public String getAgentName() {
         return agentName;
     }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
@@ -39,6 +39,8 @@ public class SlackNotificationConfig {
 	private static final String MAX_COMMITS_TO_DISPLAY = "maxCommitsToDisplay";
 	private static final String SHOW_FAILURE_REASON = "showFailureReason";
 	private static final String FILTER_BRANCH_NAME = "filterBranchName";
+	private static final String SEND_DEFAULT_CHANNEL = "sendDefaultChannel";
+	private static final String SEND_USERS = "sendUsers";
 	
 	
 	private Boolean enabled = true;
@@ -58,6 +60,8 @@ public class SlackNotificationConfig {
     private boolean customContent;
     private SlackNotificationContentConfig content;
 	private String filterBranchName;
+	private boolean sendDefaultChannel;
+	private boolean sendUsers;
 
 	@SuppressWarnings("unchecked")
 	public SlackNotificationConfig(Element e) {
@@ -110,7 +114,15 @@ public class SlackNotificationConfig {
 		if (e.getAttribute(WHO_TRIGGERED_ENABLED_MESSAGE) != null){
 			this.setMentionWhoTriggeredEnabled(Boolean.parseBoolean(e.getAttributeValue(WHO_TRIGGERED_ENABLED_MESSAGE)));
 		}
-		
+
+		if(e.getAttribute(SEND_DEFAULT_CHANNEL) != null){
+			this.setSendDefaultChannel(Boolean.parseBoolean(e.getAttributeValue("sendDefaultChannel")));
+		}
+
+		if(e.getAttribute(SEND_USERS) != null){
+			this.setSendUsers(Boolean.parseBoolean(e.getAttributeValue("sendUsers")));
+		}
+
 		if(e.getChild(STATES) != null){
 			Element eStates = e.getChild(STATES);
 			List<Element> statesList = eStates.getChildren("state");
@@ -233,7 +245,9 @@ public class SlackNotificationConfig {
 								   boolean mentionChannelEnabled,
 								   boolean mentionSlackUserEnabled,
 								   boolean mentionHereEnabled,
-								   boolean mentionWhoTriggeredEnabled) {
+								   boolean mentionWhoTriggeredEnabled,
+									 boolean sendDefaultChannel,
+									 boolean sendUsers) {
         this.content = new SlackNotificationContentConfig();
         int Min = 1000000, Max = 1000000000;
         Integer Rand = Min + (int) (Math.random() * ((Max - Min) + 1));
@@ -251,6 +265,8 @@ public class SlackNotificationConfig {
 		this.setMentionSlackUserEnabled(mentionSlackUserEnabled);
 		this.setMentionHereEnabled(mentionHereEnabled);
 		this.setMentionWhoTriggeredEnabled(mentionWhoTriggeredEnabled);
+		this.setSendDefaultChannel(sendDefaultChannel);
+		this.setSendUsers(sendUsers);
 
         if (!this.allBuildTypesEnabled) {
             this.enabledBuildTypesSet = enabledBuildTypes;
@@ -278,6 +294,8 @@ public class SlackNotificationConfig {
 		el.setAttribute(SLACK_USER_ENABLED_MESSAGE, String.valueOf(this.getMentionSlackUserEnabled()));
 		el.setAttribute(HERE_ENABLED_MESSAGE, String.valueOf(this.getMentionHereEnabled()));
 		el.setAttribute(WHO_TRIGGERED_ENABLED_MESSAGE, String.valueOf(this.isMentionWhoTriggeredEnabled()));
+		el.setAttribute(SEND_DEFAULT_CHANNEL, String.valueOf(this.getSendDefaultChannel()));
+		el.setAttribute(SEND_USERS, String.valueOf(this.getSendUsers()));
 
 		Element statesEl = new Element(STATES);
 		for (BuildStateEnum state : states.getStateSet()){
@@ -605,5 +623,21 @@ public class SlackNotificationConfig {
 
 	public void setMentionWhoTriggeredEnabled(boolean mentionWhoTriggeredEnabled) {
 		this.mentionWhoTriggeredEnabled = mentionWhoTriggeredEnabled;
+	}
+
+	public void setSendDefaultChannel(boolean sendDefaultChannel){
+    	this.sendDefaultChannel = sendDefaultChannel;
+	}
+
+	public boolean getSendDefaultChannel(){
+    	return sendDefaultChannel;
+	}
+
+	public void setSendUsers(boolean sendUsers){
+    	this.sendUsers = sendUsers;
+	}
+
+	public boolean getSendUsers(){
+    	return sendUsers;
 	}
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
@@ -340,7 +340,6 @@ public class SlackNotificationConfig {
             customContentEl.setAttribute(SHOW_FAILURE_REASON, this.content.getShowFailureReason().toString());
             el.addContent(customContentEl);
         }
-		
 		return el;
 	}
 	

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationContentConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationContentConfig.java
@@ -12,7 +12,6 @@ public class SlackNotificationContentConfig {
     public static final boolean DEFAULT_SHOW_TRIGGERED_BY = true;
     public static final boolean DEFAULT_SHOW_FAILURE_REASON = false;
     public static final String DEFAULT_FILTER_BRANCH_NAME = "";
-    public static final boolean DEFAULT_SEND_DEFAULT_CHANNEL = true;
     private String iconUrl = SlackNotificationMainConfig.DEFAULT_ICONURL;
     private String botName = SlackNotificationMainConfig.DEFAULT_BOTNAME;
     private Boolean showBuildAgent;
@@ -23,7 +22,6 @@ public class SlackNotificationContentConfig {
     private int maxCommitsToDisplay = 5;
     private boolean enabled;
     private Boolean showFailureReason;
-    private boolean sendDefaultChannel = true;
 
     public String getIconUrl() {
         return iconUrl;
@@ -105,10 +103,4 @@ public class SlackNotificationContentConfig {
         this.enabled = enabled;
     }
 
-    public void setSendDefaultChannel(boolean sendDefaultChannel) {
-        this.sendDefaultChannel = sendDefaultChannel;}
-
-    public boolean getSendDefaultChannel(){
-        return sendDefaultChannel;
-    }
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationContentConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationContentConfig.java
@@ -12,6 +12,7 @@ public class SlackNotificationContentConfig {
     public static final boolean DEFAULT_SHOW_TRIGGERED_BY = true;
     public static final boolean DEFAULT_SHOW_FAILURE_REASON = false;
     public static final String DEFAULT_FILTER_BRANCH_NAME = "";
+    public static final boolean DEFAULT_SEND_DEFAULT_CHANNEL = true;
     private String iconUrl = SlackNotificationMainConfig.DEFAULT_ICONURL;
     private String botName = SlackNotificationMainConfig.DEFAULT_BOTNAME;
     private Boolean showBuildAgent;
@@ -22,6 +23,7 @@ public class SlackNotificationContentConfig {
     private int maxCommitsToDisplay = 5;
     private boolean enabled;
     private Boolean showFailureReason;
+    private boolean sendDefaultChannel = true;
 
     public String getIconUrl() {
         return iconUrl;
@@ -103,4 +105,10 @@ public class SlackNotificationContentConfig {
         this.enabled = enabled;
     }
 
+    public void setSendDefaultChannel(boolean sendDefaultChannel) {
+        this.sendDefaultChannel = sendDefaultChannel;}
+
+    public boolean getSendDefaultChannel(){
+        return sendDefaultChannel;
+    }
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainConfig.java
@@ -1,7 +1,7 @@
 package slacknotifications.teamcity.settings;
 
 import com.intellij.openapi.util.JDOMUtil;
-import com.intellij.openapi.util.text.StringUtil;
+
 import jetbrains.buildServer.configuration.ChangeListener;
 import jetbrains.buildServer.configuration.FileWatcher;
 import jetbrains.buildServer.serverSide.ServerPaths;
@@ -14,7 +14,6 @@ import slacknotifications.teamcity.Loggers;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 
 public class SlackNotificationMainConfig implements ChangeListener {
     public static final String DEFAULT_BOTNAME = "TeamCity";
@@ -38,9 +37,11 @@ public class SlackNotificationMainConfig implements ChangeListener {
 	private static final String ENABLED = "enabled";
 	private static final String TEAM_NAME = "teamName";
 	private static final String FILTER_BRANCH_NAME = "filterBranchName";
+	private static final String SEND_DEFAULT_CHANNEL = "sendDefaultChannel";
 
 
-    private final FileWatcher myChangeObserver;
+
+	private final FileWatcher myChangeObserver;
 	private final File myConfigDir;
 	private final File myConfigFile;
 	private String slacknotificationInfoUrl = null;
@@ -56,6 +57,7 @@ public class SlackNotificationMainConfig implements ChangeListener {
     private String token;
 	private Boolean proxyShortNames = false;
     private boolean enabled = true;
+    private boolean sendDefaultChannel = true;
 	
 	public final String SINGLE_HOST_REGEX = "^[^./~`'\"]+(?:/.*)?$";
 	public final String HOSTNAME_ONLY_REGEX = "^([^/]+)(?:/.*)?$";
@@ -305,6 +307,7 @@ public class SlackNotificationMainConfig implements ChangeListener {
 						rootElement.setAttribute("token", emptyIfNull(SlackNotificationMainConfig.this.token));
 						rootElement.setAttribute("iconurl", emptyIfNull(SlackNotificationMainConfig.this.content.getIconUrl()));
 						rootElement.setAttribute("botname", emptyIfNull(SlackNotificationMainConfig.this.content.getBotName()));
+						rootElement.setAttribute(SEND_DEFAULT_CHANNEL, emptyIfNull(Boolean.toString(SlackNotificationMainConfig.this.sendDefaultChannel)));
 
 						if(SlackNotificationMainConfig.this.content.getShowBuildAgent() != null){
 							rootElement.setAttribute(SHOW_BUILD_AGENT, Boolean.toString(SlackNotificationMainConfig.this.content.getShowBuildAgent()));
@@ -417,6 +420,10 @@ public class SlackNotificationMainConfig implements ChangeListener {
             {
                 content.setShowFailureReason(Boolean.parseBoolean(slackNotificationsElement.getAttributeValue(SHOW_FAILURE_REASON)));
             }
+						if(slackNotificationsElement.getAttribute(SEND_DEFAULT_CHANNEL) != null)
+						{
+								content.setSendDefaultChannel(Boolean.parseBoolean(slackNotificationsElement.getAttributeValue(SEND_DEFAULT_CHANNEL)));
+						}
 			if(slackNotificationsElement.getAttribute(FILTER_BRANCH_NAME) != null)
 			{
 				setFilterBranchName(slackNotificationsElement.getAttributeValue(FILTER_BRANCH_NAME));

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainConfig.java
@@ -37,7 +37,6 @@ public class SlackNotificationMainConfig implements ChangeListener {
 	private static final String ENABLED = "enabled";
 	private static final String TEAM_NAME = "teamName";
 	private static final String FILTER_BRANCH_NAME = "filterBranchName";
-	private static final String SEND_DEFAULT_CHANNEL = "sendDefaultChannel";
 
 
 
@@ -57,7 +56,6 @@ public class SlackNotificationMainConfig implements ChangeListener {
     private String token;
 	private Boolean proxyShortNames = false;
     private boolean enabled = true;
-    private boolean sendDefaultChannel = true;
 	
 	public final String SINGLE_HOST_REGEX = "^[^./~`'\"]+(?:/.*)?$";
 	public final String HOSTNAME_ONLY_REGEX = "^([^/]+)(?:/.*)?$";
@@ -307,7 +305,6 @@ public class SlackNotificationMainConfig implements ChangeListener {
 						rootElement.setAttribute("token", emptyIfNull(SlackNotificationMainConfig.this.token));
 						rootElement.setAttribute("iconurl", emptyIfNull(SlackNotificationMainConfig.this.content.getIconUrl()));
 						rootElement.setAttribute("botname", emptyIfNull(SlackNotificationMainConfig.this.content.getBotName()));
-						rootElement.setAttribute(SEND_DEFAULT_CHANNEL, emptyIfNull(Boolean.toString(SlackNotificationMainConfig.this.sendDefaultChannel)));
 
 						if(SlackNotificationMainConfig.this.content.getShowBuildAgent() != null){
 							rootElement.setAttribute(SHOW_BUILD_AGENT, Boolean.toString(SlackNotificationMainConfig.this.content.getShowBuildAgent()));
@@ -420,10 +417,7 @@ public class SlackNotificationMainConfig implements ChangeListener {
             {
                 content.setShowFailureReason(Boolean.parseBoolean(slackNotificationsElement.getAttributeValue(SHOW_FAILURE_REASON)));
             }
-						if(slackNotificationsElement.getAttribute(SEND_DEFAULT_CHANNEL) != null)
-						{
-								content.setSendDefaultChannel(Boolean.parseBoolean(slackNotificationsElement.getAttributeValue(SEND_DEFAULT_CHANNEL)));
-						}
+
 			if(slackNotificationsElement.getAttribute(FILTER_BRANCH_NAME) != null)
 			{
 				setFilterBranchName(slackNotificationsElement.getAttributeValue(FILTER_BRANCH_NAME));

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
@@ -72,6 +72,7 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
             	Element el = whc.getAsElement();
             	Loggers.SERVER.debug(el.toString());
                 parentElement.addContent(el);
+
 				Loggers.SERVER.debug(NAME + ":writeTo :: channel " + whc.getChannel());
 				Loggers.SERVER.debug(NAME + ":writeTo :: enabled " + String.valueOf(whc.getEnabled()));
             }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
@@ -132,7 +132,8 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
         }    	
     }
 
-	public void updateSlackNotification(String ProjectId, String token, String slackNotificationId, String channel, String filterBranchName, Boolean enabled, BuildState buildState, boolean buildTypeAll, boolean buildSubProjects, Set<String> buildTypesEnabled, boolean mentionChannelEnabled, boolean mentionSlackUserEnabled, boolean mentionHereEnabled, boolean mentionWhoTriggeredEnabled, SlackNotificationContentConfig content) {
+	public void updateSlackNotification(String ProjectId, String token, String slackNotificationId, String channel, String filterBranchName, Boolean enabled, BuildState buildState, boolean buildTypeAll, boolean buildSubProjects, Set<String> buildTypesEnabled, boolean mentionChannelEnabled,
+																			boolean mentionSlackUserEnabled, boolean mentionHereEnabled, boolean mentionWhoTriggeredEnabled, SlackNotificationContentConfig content, boolean sendDefaultChannel, boolean sendUsers) {
         if(this.slackNotificationsConfigs != null)
         {
         	updateSuccess = false;
@@ -153,6 +154,8 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
                 	whc.enableForAllBuildsInProject(buildTypeAll);
                     whc.setHasCustomContent(content.isEnabled());
                     whc.setContent(content);
+                    whc.setSendDefaultChannel(sendDefaultChannel);
+                    whc.setSendUsers(sendUsers);
                 	if (!buildTypeAll){
                 		whc.clearAllEnabledBuildsInProject();
                 		for (String bt : buildTypesEnabled){
@@ -166,8 +169,9 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
         }    			
 	}
 
-	public void addNewSlackNotification(String ProjectId, String token, String channel, String teamName, String filterBranchName, Boolean enabled, BuildState buildState, boolean buildTypeAll, boolean buildTypeSubProjects, Set<String> buildTypesEnabled, boolean mentionChannelEnabled, boolean mentionSlackUserEnabled, boolean mentionHereEnabled, boolean mentionWhoTriggeredEnabled) {
-		this.slackNotificationsConfigs.add(new SlackNotificationConfig(token, channel, teamName, filterBranchName, enabled, buildState, buildTypeAll, buildTypeSubProjects, buildTypesEnabled, mentionChannelEnabled, mentionSlackUserEnabled, mentionHereEnabled, mentionWhoTriggeredEnabled));
+	public void addNewSlackNotification(String ProjectId, String token, String channel, String teamName, String filterBranchName, Boolean enabled, BuildState buildState, boolean buildTypeAll, boolean buildTypeSubProjects,
+																			Set<String> buildTypesEnabled, boolean mentionChannelEnabled, boolean mentionSlackUserEnabled, boolean mentionHereEnabled, boolean mentionWhoTriggeredEnabled, boolean sendDefaultChannel, boolean sendUsers) {
+		this.slackNotificationsConfigs.add(new SlackNotificationConfig(token, channel, teamName, filterBranchName, enabled, buildState, buildTypeAll, buildTypeSubProjects, buildTypesEnabled, mentionChannelEnabled, mentionSlackUserEnabled, mentionHereEnabled, mentionWhoTriggeredEnabled, sendDefaultChannel, sendUsers));
 		Loggers.SERVER.debug(NAME + ":addNewSlackNotification :: Adding slack notifications to " + ProjectId + " with channel " + channel);
 		this.updateSuccess = true;
 	}

--- a/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/SlackNotificationListenerTest.java
+++ b/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/SlackNotificationListenerTest.java
@@ -141,7 +141,7 @@ public class SlackNotificationListenerTest {
 	    BuildState buildState = new BuildState();
 	    SlackNotificationMainSettings mainSettings = new SlackNotificationMainSettings(sBuildServer, serverPaths);
 	    mainSettings.readFrom(getFullConfigElement());
-	    SlackNotificationConfig config = new SlackNotificationConfig("", "#general", "teamName", "<default>", true, buildState, true, true, null, true, true, true, true);
+	    SlackNotificationConfig config = new SlackNotificationConfig("", "#general", "teamName", "<default>", true, buildState, true, true, null, true, true, true, true, true, true);
 	    SlackNotificationListener whl = new SlackNotificationListener(sBuildServer, settings, mainSettings, manager, factory);
 	    
 	    whl.getFromConfig(slackNotificationImpl, config);
@@ -173,7 +173,7 @@ public class SlackNotificationListenerTest {
 	@Test
 	public void testBuildStartedSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState().setAllEnabled();
-		projSettings.addNewSlackNotification("", "project1", "my-channel", "myteam", "", true, state, true, true, new HashSet<String>(), true, true, true, true);
+		projSettings.addNewSlackNotification("", "project1", "my-channel", "myteam", "", true, state, true, true, new HashSet<String>(), true, true, true, true, true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.allEnabled());
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
@@ -184,7 +184,7 @@ public class SlackNotificationListenerTest {
 	@Test
 	public void testBuildFinishedSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState().setAllEnabled();
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "", true, state , true, true, new HashSet<String>(), true, true, true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "", true, state , true, true, new HashSet<String>(), true, true, true, true, true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.allEnabled());
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
@@ -198,7 +198,7 @@ public class SlackNotificationListenerTest {
 		state.enable(BuildStateEnum.BUILD_FIXED);
 		state.enable(BuildStateEnum.BUILD_FINISHED);
 		state.enable(BuildStateEnum.BUILD_SUCCESSFUL);
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", null, true, state, true, true, new HashSet<String>(), true, true, true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", null, true, state, true, true, new HashSet<String>(), true, true, true, true, true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.enabled(BuildStateEnum.BUILD_FIXED));
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedFailedBuilds);
 		
@@ -210,7 +210,7 @@ public class SlackNotificationListenerTest {
 	public void testBuildFinishedSRunningBuildSuccessAfterSuccess() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState();
 		state.enable(BuildStateEnum.BUILD_FIXED);
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", null, true, state, true, true, new HashSet<String>(), true, true, true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", null, true, state, true, true, new HashSet<String>(), true, true, true, true, true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.enabled(BuildStateEnum.BUILD_FIXED));
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
@@ -221,7 +221,7 @@ public class SlackNotificationListenerTest {
 	@Test
 	public void testBuildInterruptedSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState().setAllEnabled();
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", null, true, state, true, true, new HashSet<String>(), true, true, true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", null, true, state, true, true, new HashSet<String>(), true, true, true, true, true, true);
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
 		whl.buildInterrupted(sRunningBuild);
@@ -232,7 +232,7 @@ public class SlackNotificationListenerTest {
 	public void testBeforeBuildFinishSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState();
 		state.enable(BuildStateEnum.BEFORE_BUILD_FINISHED);
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam",  null, true, state, true, true, new HashSet<String>(), true, true, true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam",  null, true, state, true, true, new HashSet<String>(), true, true, true, true, true, true);
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
 		whl.beforeBuildFinish(sRunningBuild);

--- a/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationConfigTest.java
+++ b/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationConfigTest.java
@@ -4,10 +4,13 @@ import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.junit.Before;
 import org.junit.Test;
+
+import slacknotifications.teamcity.BuildState;
 import slacknotifications.testframework.util.ConfigLoaderUtil;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashSet;
 
 import static org.junit.Assert.*;
 
@@ -20,6 +23,7 @@ public class SlackNotificationConfigTest {
 	SlackNotificationConfig slacknotificationDisabled;
 	SlackNotificationConfig slacknotificationMostEnabled;
     SlackNotificationConfig slacknotificationCustomContent;
+    SlackNotificationConfig slacknotificationDMEnabledDefaultDisabled;
 
 
     @Before
@@ -30,6 +34,7 @@ public class SlackNotificationConfigTest {
 		slacknotificationDisabled    = ConfigLoaderUtil.getFirstSlackNotificationInConfig(new File("src/test/resources/project-settings-test-slacknotifications-disabled.xml"));
 		slacknotificationMostEnabled = ConfigLoaderUtil.getFirstSlackNotificationInConfig(new File("src/test/resources/project-settings-test-all-but-respchange-states-enabled.xml"));
         slacknotificationCustomContent = ConfigLoaderUtil.getFirstSlackNotificationInConfig(new File("src/test/resources/project-settings-test-custom-content.xml"));
+        slacknotificationDMEnabledDefaultDisabled = ConfigLoaderUtil.getFirstSlackNotificationInConfig(new File("src/test/resources/project-settings-send-DM-test.xml"));
 	}
 	
 //	private SlackNotificationConfig getFirstSlackNotificationInConfig(File f) throws JDOMException, IOException{
@@ -200,5 +205,33 @@ public class SlackNotificationConfigTest {
         assertTrue(slacknotificationCustomContent.getContent().getShowFailureReason());
         assertEquals(20, slacknotificationCustomContent.getContent().getMaxCommitsToDisplay());
     }
+
+    @Test
+		public void loadConfigWithDMEnabled(){
+    	assertTrue(slacknotificationDMEnabledDefaultDisabled.getSendUsers());
+    	assertFalse(slacknotificationDMEnabledDefaultDisabled.getSendDefaultChannel());
+    	assertTrue(slacknotificationDMEnabledDefaultDisabled.getEnabled());
+    	assertFalse(slacknotificationDMEnabledDefaultDisabled.getMentionChannelEnabled());
+    	assertFalse(slacknotificationDMEnabledDefaultDisabled.getMentionSlackUserEnabled());
+    	assertTrue(slacknotificationDMEnabledDefaultDisabled.getMentionHereEnabled());
+		}
+
+	@Test
+	public void changeConfigWithDMEnabled(){
+    SlackNotificationProjectSettings settings = new SlackNotificationProjectSettings();
+    settings.readFrom(slacknotificationDMEnabledDefaultDisabled.getAsElement());
+
+		assertTrue(slacknotificationDMEnabledDefaultDisabled.getSendUsers());
+		assertFalse(slacknotificationDMEnabledDefaultDisabled.getSendDefaultChannel());
+		BuildState state = new BuildState().setAllEnabled();
+
+		settings.updateSlackNotification("1", "1", "#general", "Steve",
+																		 "master", false, state, false, false,
+																		 new HashSet<String>(), false, false,
+																		 false, false, slacknotificationDMEnabledDefaultDisabled.getContent(), true, false);
+
+		assertTrue(slacknotificationDMEnabledDefaultDisabled.getSendUsers());
+		assertFalse(slacknotificationDMEnabledDefaultDisabled.getSendDefaultChannel());
+	}
 
 }

--- a/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettingsTest.java
+++ b/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettingsTest.java
@@ -40,7 +40,7 @@ public class SlackNotificationProjectSettingsTest {
 		settings.addNewSlackNotification("1", "1", "#general", "Steve",
 				"master", false, state, false, false,
 				new HashSet<String>(), false, false,
-				false, false);
+				false, false, true, true);
 		List<SlackNotificationConfig> listOfConfigs = settings.getSlackNotificationsConfigs();
 		for (SlackNotificationConfig config : listOfConfigs) {
 			assertTrue(config.getFilterBranchName() == "master");

--- a/tcslackbuildnotifier-core/src/test/resources/project-settings-send-DM-test.xml
+++ b/tcslackbuildnotifier-core/src/test/resources/project-settings-send-DM-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+    <slackNotifications enabled="true">
+        <slackNotification channel="#teamcity_slack_tests" token="https://hooks.slack." enabled="true" mention-channel-enabled="false" mention-slack-user-enabled="false" mention-here-enabled="true" sendDefaultChannel="false" sendUsers="true">
+            <states>
+                <state type="buildFixed" enabled="false" />
+                <state type="buildInterrupted" enabled="true" />
+                <state type="responsibilityChanged" enabled="false" />
+                <state type="buildSuccessful" enabled="true" />
+                <state type="buildStarted" enabled="false" />
+                <state type="buildBroken" enabled="false" />
+                <state type="beforeBuildFinish" enabled="false" />
+                <state type="buildFailed" enabled="true" />
+                <state type="buildFinished" enabled="true" />
+            </states>
+            <build-types enabled-for-all="true" enabled-for-subprojects="true" />
+        </slackNotification>
+    </slackNotifications>
+</settings>
+

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageController.java
@@ -137,6 +137,8 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
 										Boolean mentionWhoTriggeredEnabled = false;
 			    						Boolean buildTypeAll = false;
 			    						Boolean buildTypeSubProjects = false;
+			    						Boolean sendDefaultChannel = false;
+			    						Boolean sendUsers = false;
                                         SlackNotificationContentConfig content = new SlackNotificationContentConfig();
 			    						Set<String> buildTypes = new HashSet<String>();
 			    						if ((request.getParameter("slackNotificationsEnabled") != null )
@@ -160,6 +162,16 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
 												&& ("on".equalsIgnoreCase(request.getParameter("mentionWhoTriggeredEnabled")))){
 											mentionWhoTriggeredEnabled = true;
 										}
+
+											if ((request.getParameter("sendDefaultChannel") != null )
+												&& ("on".equalsIgnoreCase(request.getParameter("sendDefaultChannel")))){
+												sendDefaultChannel = true;
+											}
+
+											if ((request.getParameter("sendUsers") != null )
+												&& ("on".equalsIgnoreCase(request.getParameter("sendUsers")))){
+												sendUsers = true;
+											}
 
                                         content.setEnabled((request.getParameter("customContentEnabled") != null )
                                                 && ("on".equalsIgnoreCase(request.getParameter("customContentEnabled"))));
@@ -228,7 +240,7 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
 		    						
 			    						if ("new".equals(request.getParameter(SLACK_NOTIFICATION_ID))){
 			    							projSettings.addNewSlackNotification(myProject.getProjectId(), request.getParameter("token"), request.getParameter(CHANNEL), request.getParameter("team"),
-													request.getParameter("filterBranchName"), enabled, states, buildTypeAll, buildTypeSubProjects, buildTypes, mentionChannelEnabled, mentionSlackUserEnabled, mentionHereEnabled, mentionWhoTriggeredEnabled);
+													request.getParameter("filterBranchName"), enabled, states, buildTypeAll, buildTypeSubProjects, buildTypes, mentionChannelEnabled, mentionSlackUserEnabled, mentionHereEnabled, mentionWhoTriggeredEnabled, sendDefaultChannel, sendUsers);
 			    							if(projSettings.updateSuccessful()){
 			    								myProject.persist();
 			    	    						params.put(MESSAGES, ERRORS_TAG);
@@ -240,7 +252,7 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
                                                     request.getParameter(SLACK_NOTIFICATION_ID), request.getParameter(CHANNEL),
 													request.getParameter("filterBranchName"), enabled,
 													states, buildTypeAll, buildTypeSubProjects, buildTypes, mentionChannelEnabled,
-													mentionSlackUserEnabled, mentionHereEnabled, mentionWhoTriggeredEnabled, content);
+													mentionSlackUserEnabled, mentionHereEnabled, mentionWhoTriggeredEnabled, content, sendDefaultChannel, sendUsers);
 			    							if(projSettings.updateSuccessful()){
 			    								myProject.persist();
 			    	    						params.put(MESSAGES, ERRORS_TAG);

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierSettingsController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierSettingsController.java
@@ -194,7 +194,8 @@ public class SlackNotifierSettingsController extends BaseController {
         notification.setFilterBranchName(branchName);
         notification.setShowTriggeredBy(showTriggeredBy);
         notification.setShowFailureReason(showFailureReason);
-        notification.setMentionSlackUserEnabled(true);
+        notification.setMentionSlackUserEnabled(false);
+        notification.setSendDefaultChannel(false);
 
         if(proxyHost != null && !StringUtil.isEmpty(proxyHost)){
             Credentials creds = null;
@@ -218,7 +219,10 @@ public class SlackNotifierSettingsController extends BaseController {
         payload.setBuildTypeId("b123");
         payload.setColor("danger");
         List<Commit> commits = new ArrayList<Commit>();
+        commits.add(new Commit("abb23b4", "Merge of branch xyz", "Jimbo", "Jimbo.slack"));
         commits.add(new Commit("abb23b4", "Merge of branch xyz", "frankjh3", "frankie.holzapfel"));
+        //commits.add(new Commit("rahfaaf", "Testin stuff", "maxlyman", "maxlyman"));
+
         payload.setCommits(commits);
         payload.setElapsedTime(13452);
         payload.setFirstFailedBuild(true);

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierSettingsController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierSettingsController.java
@@ -62,6 +62,8 @@ public class SlackNotifierSettingsController extends BaseController {
     private PluginDescriptor descriptor;
     private String filterBranchName;
 
+    private List<Commit> addToMock = new ArrayList<Commit>();
+
     public SlackNotifierSettingsController(@NotNull SBuildServer server,
                                            @NotNull ServerPaths serverPaths,
                                            @NotNull WebControllerManager manager,
@@ -141,7 +143,7 @@ public class SlackNotifierSettingsController extends BaseController {
                 filterBranchName,
                 Boolean.parseBoolean(showTriggeredBy),
                 Boolean.parseBoolean(showFailureReason),
-                proxyHost, proxyPort, proxyUser, proxyPassword);
+                proxyHost, proxyPort, proxyUser, proxyPassword, true, false);
 
         notification.post();
 
@@ -180,7 +182,8 @@ public class SlackNotifierSettingsController extends BaseController {
                                                     Boolean showElapsedBuildTime, Boolean showBuildAgent, Boolean showCommits,
                                                     Boolean showCommitters, String branchName, Boolean showTriggeredBy,
                                                     Boolean showFailureReason, String proxyHost, String proxyPort,
-                                                    String proxyUser, String proxyPassword){
+                                                    String proxyUser, String proxyPassword,
+                                                    boolean sendDefaultChannel, boolean sendUsers){
         SlackNotification notification = new SlackNotificationImpl(defaultChannel);
         notification.setTeamName(teamName);
         notification.setBotName(botName);
@@ -195,7 +198,8 @@ public class SlackNotifierSettingsController extends BaseController {
         notification.setShowTriggeredBy(showTriggeredBy);
         notification.setShowFailureReason(showFailureReason);
         notification.setMentionSlackUserEnabled(false);
-        notification.setSendDefaultChannel(false);
+        notification.setSendDefaultChannel(sendDefaultChannel);
+        notification.setSendUsers(sendUsers);
 
         if(proxyHost != null && !StringUtil.isEmpty(proxyHost)){
             Credentials creds = null;
@@ -219,8 +223,11 @@ public class SlackNotifierSettingsController extends BaseController {
         payload.setBuildTypeId("b123");
         payload.setColor("danger");
         List<Commit> commits = new ArrayList<Commit>();
-        commits.add(new Commit("abb23b4", "Merge of branch xyz", "Jimbo", "Jimbo.slack"));
-        commits.add(new Commit("abb23b4", "Merge of branch xyz", "frankjh3", "frankie.holzapfel"));
+
+        for(Commit c : addToMock){
+            commits.add(c);
+        }
+
         //commits.add(new Commit("rahfaaf", "Testin stuff", "maxlyman", "maxlyman"));
 
         payload.setCommits(commits);
@@ -238,6 +245,10 @@ public class SlackNotifierSettingsController extends BaseController {
 
         }
         return notification;
+    }
+
+    public void addCommitMockNotification(Commit c){
+        addToMock.add(c);
     }
 
     public Integer tryParseInt(String str) {

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/ProjectSlackNotificationsBean.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/ProjectSlackNotificationsBean.java
@@ -23,7 +23,7 @@ public class ProjectSlackNotificationsBean {
 		bean.slackNotificationList = new LinkedHashMap<String, SlacknotificationConfigAndBuildTypeListHolder>();
 
 		/* Create a "new" config with blank stuff so that clicking the "new" button has a bunch of defaults to load in */
-		SlackNotificationConfig newBlankConfig = new SlackNotificationConfig("", "", "", "", true, new BuildState().setAllEnabled(), true, true, null, true, true, true, true);
+		SlackNotificationConfig newBlankConfig = new SlackNotificationConfig("", "", "", "", true, new BuildState().setAllEnabled(), true, true, null, true, true, true, true, true, true);
 		newBlankConfig.setUniqueKey("new");
 		/* And add it to the list */
 		addSlackNotificationConfigHolder(bean, projectBuildTypes, newBlankConfig, mainSettings);
@@ -47,7 +47,7 @@ public class ProjectSlackNotificationsBean {
 		bean.slackNotificationList = new LinkedHashMap<String, SlacknotificationConfigAndBuildTypeListHolder>();
 		
 		/* Create a "new" config with blank stuff so that clicking the "new" button has a bunch of defaults to load in */
-		SlackNotificationConfig newBlankConfig = new SlackNotificationConfig("", "", "", "", true, new BuildState().setAllEnabled(), false, false, enabledBuildTypes, true, true, true, true);
+		SlackNotificationConfig newBlankConfig = new SlackNotificationConfig("", "", "", "", true, new BuildState().setAllEnabled(), false, false, enabledBuildTypes, true, true, true, true, true, true);
 		newBlankConfig.setUniqueKey("new");
 		/* And add it to the list */
 		addSlackNotificationConfigHolder(bean, projectBuildTypes, newBlankConfig, mainSettings);

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/SlacknotificationConfigAndBuildTypeListHolder.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/SlacknotificationConfigAndBuildTypeListHolder.java
@@ -42,6 +42,8 @@ public class SlacknotificationConfigAndBuildTypeListHolder {
     private String filterBranchName;
     private String botName;
     private String iconUrl;
+    private boolean sendDefaultChannel;
+    private boolean sendUsers;
 
 	public SlacknotificationConfigAndBuildTypeListHolder(SlackNotificationConfig config, SlackNotificationMainSettings mainSettings) {
 		token = config.getToken();
@@ -70,6 +72,8 @@ public class SlacknotificationConfigAndBuildTypeListHolder {
         filterBranchName = valueOrFallback(config.getFilterBranchName(), valueOrFallback(mainSettings.getFilterBranchName(),SlackNotificationContentConfig.DEFAULT_FILTER_BRANCH_NAME));
         botName = valueOrFallback(config.getContent().getBotName(), SlackNotificationMainConfig.DEFAULT_BOTNAME);
         iconUrl = valueOrFallback(config.getContent().getIconUrl(), SlackNotificationMainConfig.DEFAULT_ICONURL);
+        sendDefaultChannel = config.getSendDefaultChannel();
+        sendUsers = config.getSendUsers();
 	}
 
 	

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/index.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/index.jsp
@@ -151,6 +151,10 @@
 					jQuerySlacknotification('#botName').val(slacknotification.botName);
 					jQuerySlacknotification('#iconUrl').val(slacknotification.iconUrl)
 					jQuerySlacknotification('#showFailureReason').attr('checked', slacknotification.showFailureReason);
+					jQuerySlacknotification('#sendDefaultChannel').attr('checked', slacknotification.sendDefaultChannel);
+					jQuerySlacknotification('#sendUsers').attr('checked', slacknotification.sendUsers);
+
+
 				}
 			});
 			updateSelectedBuildTypes();

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
@@ -151,8 +151,19 @@
 													</td>
 												</tr>
 												<tr style="border:none;">
-													<td>Mention on first failure:</td>
-													<td style="padding-left:3px;"><label style='white-space:nowrap;'>
+													<td>Send or mention on first failure:</td>
+
+													<td><label style='white-space:nowrap;'>
+                                                    	<input class="buildState" id="sendDefaultChannel" name="SendDefaultChannel" type=checkbox />
+                                                    	Send to Channel</label>
+                                                    </td>
+                                                    <td><label style='white-space:nowrap;'>
+                                                        <input class="buildState" id="sendUsers" name="sendUsers" type=checkbox />
+                                                        Send to recent commits</label>
+                                                    </td>
+												</tr>
+												<tr style="border:none;"><td>&nbsp;</td>
+                                                    <td style="padding-left:3px;"><label style='white-space:nowrap;'>
 														<input class="buildState" id="mentionChannelEnabled" name="mentionChannelEnabled" type=checkbox />
 														 @channel</label>
 													</td>
@@ -160,13 +171,15 @@
 														<input class="buildState" id="mentionSlackUserEnabled" name="mentionSlackUserEnabled" type=checkbox />
 														 Slack User (if known)</label>
 													</td>
+
 												</tr>
 												<tr style="border:none;"><td>&nbsp;</td>
-													<td><label style='white-space:nowrap;'>
+                                                    <td><label style='white-space:nowrap;'>
                                                         <input class="buildState" id="mentionHereEnabled" name="mentionHereEnabled" type=checkbox />
                                                          @here</label>
 													</td>
-												</tr>
+
+                                                </tr>
 												<tr style="border:none;">
 													<td><label for="mentionWhoTriggeredEnabled">Mention who triggered:</label></td>
 													<td style="padding-left:3px;" colspan=2><input id="mentionWhoTriggeredEnabled" type=checkbox name="mentionWhoTriggeredEnabled"/></td>

--- a/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/SlackNotificationDMTests.java
+++ b/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/SlackNotificationDMTests.java
@@ -1,5 +1,6 @@
 package slacknotifications.teamcity.extension;
 
+import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -10,6 +11,7 @@ import jetbrains.buildServer.web.openapi.WebControllerManager;
 import slacknotifications.SlackNotification;
 import slacknotifications.SlackNotificationImpl;
 import slacknotifications.teamcity.payload.SlackNotificationPayloadManager;
+import slacknotifications.teamcity.payload.content.Commit;
 import slacknotifications.teamcity.payload.content.SlackNotificationPayloadContent;
 import slacknotifications.teamcity.settings.SlackNotificationMainConfig;
 
@@ -22,9 +24,10 @@ public class SlackNotificationDMTests {
 
   SBuildServer sBuildServer = mock(SBuildServer.class);
   WebControllerManager webControllerManager = mock(WebControllerManager.class);
+  SlackNotifierSettingsController controller;
 
-  @Test
-  public void sendToSpecifiedChannel() throws IOException {
+  @Before
+  public void initializeConfigs(){
     String expectedConfigDirectory = ".";
     ServerPaths serverPaths = mock(ServerPaths.class);
     when(serverPaths.getConfigDir()).thenReturn(expectedConfigDirectory);
@@ -34,9 +37,38 @@ public class SlackNotificationDMTests {
     SlackNotificationMainConfig config = new SlackNotificationMainConfig(serverPaths);
     SlackNotificationPayloadManager payloadManager = new SlackNotificationPayloadManager(sBuildServer);
 
-    SlackNotifierSettingsController controller = new SlackNotifierSettingsController(
+    controller = new SlackNotifierSettingsController(
       sBuildServer, serverPaths, webControllerManager,
       config, payloadManager, pluginDescriptor);
+  }
+
+  private SlackNotification sendMock(boolean sendChannel){
+    SlackNotification notification = controller.createMockNotification(
+      "tamr",
+      "#teamcity_slack_tests",
+      "Test Bot",
+      "https://hooks.slack.com/services/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",
+      SlackNotificationMainConfig.DEFAULT_ICONURL,
+      5,
+      true,
+      true,
+      true,
+      true,
+      "master",
+      false,
+      true,
+      null, null, null, null, sendChannel, true);
+
+    return notification;
+  }
+
+
+
+  @Test
+  public void sendToDefaultChannelTest() throws IOException {
+
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "Jimbo", "Jimbo.slack"));
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "frankjh3", "frankie.holzapfel"));
 
     SlackNotification notification = controller.createMockNotification(
       "tamr",
@@ -52,9 +84,124 @@ public class SlackNotificationDMTests {
       "master",
       false,
       true,
-      null, null, null, null);
+      null, null, null, null, true, false);
 
     assertNotNull(notification);
+  }
+
+  @Test
+  public void sendToCommitUsersTest() throws IOException {
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "Jimbo", "Jimbo.slack"));
+    controller.addCommitMockNotification(new Commit("abb23b4", "commiting stuff from frankjh3", "frankjh3", "frankie.holzapfel"));
+
+    assertNotNull(sendMock(true));
+  }
+
+  @Test
+  public void multipleCommitsOneUserTest() throws IOException {
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "Jimbo", "Jimbo.slack"));
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "Did some stuff", "frankjh3", "frankie.holzapfel"));
+
+    assertNotNull(sendMock(true));
+  }
+
+  @Test
+  public void mergePullRequestOtherTest() throws IOException {
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "Jimbo", "Jimbo.slack"));
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "rick", "rick.slack"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "Merge pull request #15208 from rick/authz.service", "frankjh3", "frankie.holzapfel"));
+
+    assertNotNull(sendMock(true));
+  }
+
+  @Test
+  public void mergePullRequestSameTest() throws IOException {
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "Jimbo", "Jimbo.slack"));
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "rick", "rick.slack"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "Merge pull request #15208 from frankjh3/authz.service", "frankjh3", "frankie.holzapfel"));
+
+    assertNotNull(sendMock(true));
+  }
+
+  @Test
+  public void multipleCommitsOneUserSpacedTest() throws IOException {
+    controller.addCommitMockNotification(new Commit("jdajfla", "early commits", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "Jimbo", "Jimbo.slack"));
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "rick", "rick.slack"));
+    controller.addCommitMockNotification(new Commit("adijefp", "branch xyz", "rick", "rick.slack"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "later commits", "frankjh3", "frankie.holzapfel"));
+
+    assertNotNull(sendMock(true));
+  }
+
+  @Test
+  public void afterFifthCommitUserTest() throws IOException {
+    controller.addCommitMockNotification(new Commit("jdajfla", "first commit", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "second commit", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "early commits", "jdasfj", "fake.slack"));
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "Jimbo", "Jimbo.slack"));
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "rick", "rick.slack"));
+    controller.addCommitMockNotification(new Commit("adijefp", "branch xyz", "rick", "rick.slack"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "early commits", "jdasfj", "fake.slack"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "early commits", "jdasfj", "fake.slack"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "early commits", "jdasfj", "fake.slack"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "later commits", "frankjh3", "frankie.holzapfel"));
+
+    assertNotNull(sendMock(true));
+  }
+
+  @Test
+  public void afterFifthOnlyUserTest() throws IOException {
+    controller.addCommitMockNotification(new Commit("jdajfla", "first commit", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "second commit", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "later commits", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "first commit", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "second commit", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "later commits", "frankjh3", "frankie.holzapfel"));
+
+    assertNotNull(sendMock(true));
+  }
+
+  @Test
+  public void lessThanFiveOthersTest() throws IOException {
+    controller.addCommitMockNotification(new Commit("jdajfla", "first commit", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "second commit", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "early commits", "jdasfj", "fake.slack"));
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "Jimbo", "Jimbo.slack"));
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "rick", "rick.slack"));
+    controller.addCommitMockNotification(new Commit("adijefp", "branch xyz", "rick", "rick.slack"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "later commits", "frankjh3", "frankie.holzapfel"));
+
+    assertNotNull(sendMock(true));
+  }
+
+  @Test
+  public void oneMoreCommitsTest() throws IOException {
+    controller.addCommitMockNotification(new Commit("jdajfla", "first commit", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "second commit", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "later commits", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("dsalfhh", "other", "adfaafa", "fake.slack"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "first commit", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "second commit", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "later commits", "frankjh3", "frankie.holzapfel"));
+
+    assertNotNull(sendMock(true));
+  }
+
+  @Test
+  public void nMoreCommitsTest() throws IOException {
+    controller.addCommitMockNotification(new Commit("jdajfla", "first commit", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "second commit", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("dsalfhh", "other", "adfaafa", "fake.slack"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "later commits", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("dsalfhh", "other", "adfaafa", "fake.slack"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "first commit", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "second commit", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("dsalfhh", "other", "adfaafa", "fake.slack"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "later commits", "frankjh3", "frankie.holzapfel"));
+
+    assertNotNull(sendMock(true));
   }
 }
 

--- a/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/SlackNotificationDMTests.java
+++ b/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/SlackNotificationDMTests.java
@@ -40,7 +40,7 @@ public class SlackNotificationDMTests {
 
     SlackNotification notification = controller.createMockNotification(
       "tamr",
-      "@frankie.holzapfel",
+      "#teamcity_slack_tests",
       "Test Bot",
       "https://hooks.slack.com/services/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",
       SlackNotificationMainConfig.DEFAULT_ICONURL,
@@ -50,7 +50,7 @@ public class SlackNotificationDMTests {
       true,
       true,
       "master",
-      true,
+      false,
       true,
       null, null, null, null);
 

--- a/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/SlackNotificationSettingsControllerTest.java
+++ b/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/SlackNotificationSettingsControllerTest.java
@@ -49,7 +49,7 @@ public class SlackNotificationSettingsControllerTest {
                 "master",
                 true,
                 true,
-                null, null, null, null);
+                null, null, null, null, true, true);
 
         assertNotNull(notification);
         assertEquals("the team", notification.getTeamName());

--- a/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/bean/ProjectSlackNotificationsBeanTest.java
+++ b/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/bean/ProjectSlackNotificationsBeanTest.java
@@ -20,26 +20,35 @@ public class ProjectSlackNotificationsBeanTest {
 
 	SortedMap<String, String> map = new TreeMap<String, String>();
 	SlackNotificationMockingFramework framework;
-    SBuildServer sBuildServer = mock(SBuildServer.class);
+	SBuildServer sBuildServer = mock(SBuildServer.class);
 
 	@Test
 	public void JsonSerialisationTest() throws JDOMException, IOException {
-        ServerPaths serverPaths = mock(ServerPaths.class);
-        SlackNotificationMainSettings myMainSettings = new SlackNotificationMainSettings(sBuildServer, serverPaths);
-        framework = SlackNotificationMockingFrameworkImpl.create(BuildStateEnum.BUILD_FINISHED);
+		ServerPaths serverPaths = mock(ServerPaths.class);
+		SlackNotificationMainSettings myMainSettings = new SlackNotificationMainSettings(sBuildServer, serverPaths);
+		framework = SlackNotificationMockingFrameworkImpl.create(BuildStateEnum.BUILD_FINISHED);
 		framework.loadSlackNotificationProjectSettingsFromConfigXml(new File("../tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-states-enabled-with-specific-builds.xml"));
-		ProjectSlackNotificationsBean slacknotificationsConfig = ProjectSlackNotificationsBean.build(framework.getSlackNotificationProjectSettings() , framework.getServer().getProjectManager().findProjectById("project01"), myMainSettings);
-		System.out.println(ProjectSlackNotificationsBeanJsonSerialiser.serialise(slacknotificationsConfig));
-	}
-	
-	@Test
-	public void JsonBuildSerialisationTest() throws JDOMException, IOException {
-        ServerPaths serverPaths = mock(ServerPaths.class);
-        SlackNotificationMainSettings myMainSettings = new SlackNotificationMainSettings(sBuildServer, serverPaths);
-        framework = SlackNotificationMockingFrameworkImpl.create(BuildStateEnum.BUILD_FINISHED);
-		framework.loadSlackNotificationProjectSettingsFromConfigXml(new File("../tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-states-enabled-with-specific-builds.xml"));
-		ProjectSlackNotificationsBean slacknotificationsConfig = ProjectSlackNotificationsBean.build(framework.getSlackNotificationProjectSettings() ,framework.getSBuildType() ,framework.getServer().getProjectManager().findProjectById("project01"), myMainSettings);
+		ProjectSlackNotificationsBean slacknotificationsConfig = ProjectSlackNotificationsBean.build(framework.getSlackNotificationProjectSettings(), framework.getServer().getProjectManager().findProjectById("project01"), myMainSettings);
 		System.out.println(ProjectSlackNotificationsBeanJsonSerialiser.serialise(slacknotificationsConfig));
 	}
 
+	@Test
+	public void JsonBuildSerialisationTest() throws JDOMException, IOException {
+		ServerPaths serverPaths = mock(ServerPaths.class);
+		SlackNotificationMainSettings myMainSettings = new SlackNotificationMainSettings(sBuildServer, serverPaths);
+		framework = SlackNotificationMockingFrameworkImpl.create(BuildStateEnum.BUILD_FINISHED);
+		framework.loadSlackNotificationProjectSettingsFromConfigXml(new File("../tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-states-enabled-with-specific-builds.xml"));
+		ProjectSlackNotificationsBean slacknotificationsConfig = ProjectSlackNotificationsBean.build(framework.getSlackNotificationProjectSettings(), framework.getSBuildType(), framework.getServer().getProjectManager().findProjectById("project01"), myMainSettings);
+		System.out.println(ProjectSlackNotificationsBeanJsonSerialiser.serialise(slacknotificationsConfig));
+	}
+
+	@Test
+	public void loadDMSettingsTest() throws JDOMException, IOException {
+		ServerPaths serverPaths = mock(ServerPaths.class);
+		SlackNotificationMainSettings myMainSettings = new SlackNotificationMainSettings(sBuildServer, serverPaths);
+		framework = SlackNotificationMockingFrameworkImpl.create(BuildStateEnum.BUILD_FINISHED);
+		framework.loadSlackNotificationProjectSettingsFromConfigXml(new File("../tcslackbuildnotifier-core/src/test/resources/project-settings-send-DM-test.xml"));
+		ProjectSlackNotificationsBean slacknotificationsConfig = ProjectSlackNotificationsBean.build(framework.getSlackNotificationProjectSettings(), framework.getServer().getProjectManager().findProjectById("project01"), myMainSettings);
+		System.out.println(ProjectSlackNotificationsBeanJsonSerialiser.serialise(slacknotificationsConfig));
+	}
 }


### PR DESCRIPTION
Add option to send direct message to the users who were responsible for changes in the tested build. Direct messages and sending to the specified channel can be enabled/disabled. Options for these were added to the UI along with tests to check if the configuration changed when updating settings. 
Commits of the user who the message is sent to are separated under "Your commits" and prioritized when the total number of commits exceeds the amount to display.