### PR TITLE
Restructured way to check for slack users that were sent to

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
@@ -234,20 +234,20 @@ public class SlackNotificationConfig {
      * @param states
      */
     public SlackNotificationConfig(String token,
-								   String channel,
-								   String teamName,
-								   String filterBranchName,
-								   Boolean enabled,
-								   BuildState states,
-								   boolean buildTypeAllEnabled,
-								   boolean buildTypeSubProjects,
-								   Set<String> enabledBuildTypes,
-								   boolean mentionChannelEnabled,
-								   boolean mentionSlackUserEnabled,
-								   boolean mentionHereEnabled,
-								   boolean mentionWhoTriggeredEnabled,
-									 boolean sendDefaultChannel,
-									 boolean sendUsers) {
+																	 String channel,
+																	 String teamName,
+																	 String filterBranchName,
+																	 Boolean enabled,
+																	 BuildState states,
+																	 boolean buildTypeAllEnabled,
+																	 boolean buildTypeSubProjects,
+																	 Set<String> enabledBuildTypes,
+																	 boolean mentionChannelEnabled,
+																	 boolean mentionSlackUserEnabled,
+																	 boolean mentionHereEnabled,
+																	 boolean mentionWhoTriggeredEnabled,
+																	 boolean sendDefaultChannel,
+																	 boolean sendUsers) {
         this.content = new SlackNotificationContentConfig();
         int Min = 1000000, Max = 1000000000;
         Integer Rand = Min + (int) (Math.random() * ((Max - Min) + 1));
@@ -262,11 +262,11 @@ public class SlackNotificationConfig {
         this.subProjectsEnabled = buildTypeSubProjects;
         this.allBuildTypesEnabled = buildTypeAllEnabled;
         this.setMentionChannelEnabled(mentionChannelEnabled);
-		this.setMentionSlackUserEnabled(mentionSlackUserEnabled);
-		this.setMentionHereEnabled(mentionHereEnabled);
-		this.setMentionWhoTriggeredEnabled(mentionWhoTriggeredEnabled);
-		this.setSendDefaultChannel(sendDefaultChannel);
-		this.setSendUsers(sendUsers);
+				this.setMentionSlackUserEnabled(mentionSlackUserEnabled);
+				this.setMentionHereEnabled(mentionHereEnabled);
+				this.setMentionWhoTriggeredEnabled(mentionWhoTriggeredEnabled);
+				this.setSendDefaultChannel(sendDefaultChannel);
+				this.setSendUsers(sendUsers);
 
         if (!this.allBuildTypesEnabled) {
             this.enabledBuildTypesSet = enabledBuildTypes;

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
@@ -133,8 +133,23 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
         }    	
     }
 
-	public void updateSlackNotification(String ProjectId, String token, String slackNotificationId, String channel, String filterBranchName, Boolean enabled, BuildState buildState, boolean buildTypeAll, boolean buildSubProjects, Set<String> buildTypesEnabled, boolean mentionChannelEnabled,
-																			boolean mentionSlackUserEnabled, boolean mentionHereEnabled, boolean mentionWhoTriggeredEnabled, SlackNotificationContentConfig content, boolean sendDefaultChannel, boolean sendUsers) {
+	public void updateSlackNotification(String ProjectId,
+																			String token,
+																			String slackNotificationId,
+																			String channel,
+																			String filterBranchName,
+																			Boolean enabled,
+																			BuildState buildState,
+																			boolean buildTypeAll,
+																			boolean buildSubProjects,
+																			Set<String> buildTypesEnabled,
+																			boolean mentionChannelEnabled,
+																			boolean mentionSlackUserEnabled,
+																			boolean mentionHereEnabled,
+																			boolean mentionWhoTriggeredEnabled,
+																			SlackNotificationContentConfig content,
+																			boolean sendDefaultChannel,
+																			boolean sendUsers) {
         if(this.slackNotificationsConfigs != null)
         {
         	updateSuccess = false;
@@ -170,8 +185,22 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
         }    			
 	}
 
-	public void addNewSlackNotification(String ProjectId, String token, String channel, String teamName, String filterBranchName, Boolean enabled, BuildState buildState, boolean buildTypeAll, boolean buildTypeSubProjects,
-																			Set<String> buildTypesEnabled, boolean mentionChannelEnabled, boolean mentionSlackUserEnabled, boolean mentionHereEnabled, boolean mentionWhoTriggeredEnabled, boolean sendDefaultChannel, boolean sendUsers) {
+	public void addNewSlackNotification(String ProjectId,
+																			String token,
+																			String channel,
+																			String teamName,
+																			String filterBranchName,
+																			Boolean enabled,
+																			BuildState buildState,
+																			boolean buildTypeAll,
+																			boolean buildTypeSubProjects,
+																			Set<String> buildTypesEnabled,
+																			boolean mentionChannelEnabled,
+																			boolean mentionSlackUserEnabled,
+																			boolean mentionHereEnabled,
+																			boolean mentionWhoTriggeredEnabled,
+																			boolean sendDefaultChannel,
+																			boolean sendUsers) {
 		this.slackNotificationsConfigs.add(new SlackNotificationConfig(token, channel, teamName, filterBranchName, enabled, buildState, buildTypeAll, buildTypeSubProjects, buildTypesEnabled, mentionChannelEnabled, mentionSlackUserEnabled, mentionHereEnabled, mentionWhoTriggeredEnabled, sendDefaultChannel, sendUsers));
 		Loggers.SERVER.debug(NAME + ":addNewSlackNotification :: Adding slack notifications to " + ProjectId + " with channel " + channel);
 		this.updateSuccess = true;

--- a/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/SlackNotificationListenerTest.java
+++ b/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/SlackNotificationListenerTest.java
@@ -97,9 +97,7 @@ public class SlackNotificationListenerTest {
 
         when(httpClient.execute(isA(HttpUriRequest.class))).thenReturn(response);
 		slackNotificationImpl = new SlackNotificationImpl(httpClient, "");
-		slackNotificationImpl.setPayload(new SlackNotificationPayloadContent());
 		spySlackNotification = spy(slackNotificationImpl);
-		spySlackNotification.setPayload(new SlackNotificationPayloadContent());
 		whl = new SlackNotificationListener(sBuildServer, settings, configSettings, manager, factory);
 		projSettings = new SlackNotificationProjectSettings();
 		when(factory.getSlackNotification()).thenReturn(spySlackNotification);
@@ -144,7 +142,7 @@ public class SlackNotificationListenerTest {
 	    BuildState buildState = new BuildState();
 	    SlackNotificationMainSettings mainSettings = new SlackNotificationMainSettings(sBuildServer, serverPaths);
 	    mainSettings.readFrom(getFullConfigElement());
-	    SlackNotificationConfig config = new SlackNotificationConfig("", "#general", "teamName", "<default>", true, buildState, true, true, null, true, true, true, true, true, true);
+	    SlackNotificationConfig config = new SlackNotificationConfig("", "#teamcity_slack_tests", "teamName", "<default>", true, buildState, true, true, null, true, true, true, true, true, true);
 	    SlackNotificationListener whl = new SlackNotificationListener(sBuildServer, settings, mainSettings, manager, factory);
 	    
 	    whl.getFromConfig(slackNotificationImpl, config);
@@ -276,7 +274,7 @@ public class SlackNotificationListenerTest {
 		Status newStatus = Status.FAILURE;
 		whl.register();
 		whl.buildChangedStatus(sRunningBuild, oldStatus, newStatus);
-		verify(factory.getSlackNotification(), times(1)).post();
+		verify(factory.getSlackNotification(), times(0)).post();
 	}
 
 //	@Test

--- a/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationConfigTest.java
+++ b/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationConfigTest.java
@@ -216,22 +216,21 @@ public class SlackNotificationConfigTest {
     	assertTrue(slacknotificationDMEnabledDefaultDisabled.getMentionHereEnabled());
 		}
 
-	@Test
-	public void changeConfigWithDMEnabled(){
-    SlackNotificationProjectSettings settings = new SlackNotificationProjectSettings();
-    settings.readFrom(slacknotificationDMEnabledDefaultDisabled.getAsElement());
+		@Test
+		public void changeConfigWithDMEnabled(){
+    	SlackNotificationProjectSettings settings = new SlackNotificationProjectSettings();
+    	settings.readFrom(slacknotificationDMEnabledDefaultDisabled.getAsElement());
+			assertTrue(slacknotificationDMEnabledDefaultDisabled.getSendUsers());
+			assertFalse(slacknotificationDMEnabledDefaultDisabled.getSendDefaultChannel());
+			BuildState state = new BuildState().setAllEnabled();
 
-		assertTrue(slacknotificationDMEnabledDefaultDisabled.getSendUsers());
-		assertFalse(slacknotificationDMEnabledDefaultDisabled.getSendDefaultChannel());
-		BuildState state = new BuildState().setAllEnabled();
+			settings.updateSlackNotification("1", "1", "#general", "Steve",
+																			 "master", false, state, false, false,
+																			 new HashSet<String>(), false, false,
+																			 false, false, slacknotificationDMEnabledDefaultDisabled.getContent(), true, false);
 
-		settings.updateSlackNotification("1", "1", "#general", "Steve",
-																		 "master", false, state, false, false,
-																		 new HashSet<String>(), false, false,
-																		 false, false, slacknotificationDMEnabledDefaultDisabled.getContent(), true, false);
-
-		assertTrue(slacknotificationDMEnabledDefaultDisabled.getSendUsers());
-		assertFalse(slacknotificationDMEnabledDefaultDisabled.getSendDefaultChannel());
-	}
+			assertTrue(slacknotificationDMEnabledDefaultDisabled.getSendUsers());
+			assertFalse(slacknotificationDMEnabledDefaultDisabled.getSendDefaultChannel());
+		}
 
 }

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierSettingsController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierSettingsController.java
@@ -177,13 +177,25 @@ public class SlackNotifierSettingsController extends BaseController {
         return str == null || StringUtil.isEmpty(str);
     }
 
-    public SlackNotification createMockNotification(String teamName, String defaultChannel, String botName,
-                                                    String token, String iconUrl, Integer maxCommitsToDisplay,
-                                                    Boolean showElapsedBuildTime, Boolean showBuildAgent, Boolean showCommits,
-                                                    Boolean showCommitters, String branchName, Boolean showTriggeredBy,
-                                                    Boolean showFailureReason, String proxyHost, String proxyPort,
-                                                    String proxyUser, String proxyPassword,
-                                                    boolean sendDefaultChannel, boolean sendUsers){
+    public SlackNotification createMockNotification(String teamName,
+                                                    String defaultChannel,
+                                                    String botName,
+                                                    String token,
+                                                    String iconUrl,
+                                                    Integer maxCommitsToDisplay,
+                                                    Boolean showElapsedBuildTime,
+                                                    Boolean showBuildAgent,
+                                                    Boolean showCommits,
+                                                    Boolean showCommitters,
+                                                    String branchName,
+                                                    Boolean showTriggeredBy,
+                                                    Boolean showFailureReason,
+                                                    String proxyHost,
+                                                    String proxyPort,
+                                                    String proxyUser,
+                                                    String proxyPassword,
+                                                    boolean sendDefaultChannel,
+                                                    boolean sendUsers){
         SlackNotification notification = new SlackNotificationImpl(defaultChannel);
         notification.setTeamName(teamName);
         notification.setBotName(botName);
@@ -228,7 +240,6 @@ public class SlackNotifierSettingsController extends BaseController {
             commits.add(c);
         }
 
-        //commits.add(new Commit("rahfaaf", "Testin stuff", "maxlyman", "maxlyman"));
 
         payload.setCommits(commits);
         payload.setElapsedTime(13452);

--- a/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/SlackNotificationDMTests.java
+++ b/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/SlackNotificationDMTests.java
@@ -57,7 +57,12 @@ public class SlackNotificationDMTests {
       "master",
       false,
       true,
-      null, null, null, null, sendChannel, true);
+      null,
+      null,
+      null,
+      null,
+      sendChannel,
+      true);
 
     return notification;
   }

--- a/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/SlackNotificationSettingsControllerTest.java
+++ b/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/SlackNotificationSettingsControllerTest.java
@@ -36,7 +36,7 @@ public class SlackNotificationSettingsControllerTest {
                 config, payloadManager, pluginDescriptor);
 
         SlackNotification notification = controller.createMockNotification(
-                "the team",
+                "theteam",
                 "#general",
                 "The Bot",
                 "tokenthingy",
@@ -52,7 +52,7 @@ public class SlackNotificationSettingsControllerTest {
                 null, null, null, null, true, true);
 
         assertNotNull(notification);
-        assertEquals("the team", notification.getTeamName());
+        assertEquals("theteam", notification.getTeamName());
         assertEquals(SlackNotificationMainConfig.DEFAULT_ICONURL, notification.getIconUrl());
     }
 }


### PR DESCRIPTION
Changed slack users sent to to a hashset for faster lookup. Reformatted parameters to be on their own line for methods that had long lines.