### PR TITLE
Added option to send notification as soon as part of build fails

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
@@ -490,12 +490,11 @@ public class SlackNotificationImpl implements SlackNotification {
   }
 
   private void addCommitToMessage(List<Commit> commits, StringBuilder sbCommits){
-    Commit commit = commits.get(0);
+    Commit commit = commits.remove(0);
     String revision = commit.getRevision();
     revision = revision == null ? "" : revision;
 
     sbCommits.append(String.format("%s :: %s :: %s\n", revision.substring(0, Math.min(revision.length(), 10)), commit.getUserName(), commit.getDescription()));
-    commits.remove(0);
   }
 
   private class WebHookPayload {

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/BuildState.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/BuildState.java
@@ -24,6 +24,12 @@ public class BuildState {
     states.put(BuildStateEnum.BUILD_FIXED, new SimpleBuildState(BuildStateEnum.BUILD_FIXED, false));
 
     states.put(BuildStateEnum.BUILD_FINISHED, new SimpleBuildState(BuildStateEnum.BUILD_FINISHED, false));
+
+    states.put(BuildStateEnum.BUILD_CHANGED_STATUS, new SimpleBuildState(BuildStateEnum.BUILD_CHANGED_STATUS, false));
+
+    states.put(BuildStateEnum.BUILD_BROKE_MID, new SimpleBuildState(BuildStateEnum.BUILD_BROKE_MID, false));
+    states.put(BuildStateEnum.BUILD_BROKE_MID_CHANGE, new SimpleBuildState(BuildStateEnum.BUILD_BROKE_MID_CHANGE, false));
+
   }
 
   public Set<BuildStateEnum> getStateSet() {
@@ -44,9 +50,7 @@ public class BuildState {
   }
 
   public boolean enabled(BuildStateEnum currentBuildState, boolean success, boolean changed) {
-    if (currentBuildState != BuildStateEnum.BUILD_FINISHED) {
-      return enabled(currentBuildState);
-    } else {
+    if (currentBuildState == BuildStateEnum.BUILD_FINISHED) {
       if (enabled(BUILD_SUCCESSFUL) && enabled(BUILD_FIXED) && changed && success) {
         return true;
       }
@@ -59,6 +63,15 @@ public class BuildState {
       if (enabled(BUILD_FAILED) && !enabled(BUILD_BROKEN) && !success) {
         return true;
       }
+    } else if(currentBuildState == BuildStateEnum.BUILD_CHANGED_STATUS){
+      if (enabled(BUILD_BROKE_MID) && enabled(BUILD_BROKE_MID_CHANGE) && changed && !success) {
+        return true;
+      }
+      if (enabled(BUILD_BROKE_MID) && !enabled(BUILD_BROKE_MID_CHANGE) && !success) {
+        return true;
+      }
+    } else {
+      return enabled(currentBuildState);
     }
     return false;
   }
@@ -72,7 +85,7 @@ public class BuildState {
 
   /**
    * Enable all build events for notification
-   * Note: BROKEN and FIXED restrict builds, so don't set those.
+   * Note: BROKEN, FIXED, and BROKE_MID_CHANGE restrict builds, so don't set those.
    */
   public BuildState setAllEnabled() {
     for (BuildStateEnum state : states.keySet()) {
@@ -81,6 +94,9 @@ public class BuildState {
           disable(state);
           break;
         case BUILD_FIXED:
+          disable(state);
+          break;
+        case BUILD_BROKE_MID_CHANGE:
           disable(state);
           break;
         default:
@@ -141,7 +157,7 @@ public class BuildState {
           enabled++;
         }
       }
-      if (state.equals(BUILD_FINISHED) || state.equals(BUILD_BROKEN) || state.equals(BUILD_FIXED) || state.equals(BUILD_SUCCESSFUL) || state.equals(BUILD_FAILED)) {
+      if (state.equals(BUILD_FINISHED) || state.equals(BUILD_BROKEN) || state.equals(BUILD_FIXED) || state.equals(BUILD_SUCCESSFUL) || state.equals(BUILD_FAILED) || state.equals(BUILD_BROKE_MID)) {
         continue;
       }
       if (states.get(state).isEnabled()) {

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/BuildStateEnum.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/BuildStateEnum.java
@@ -3,14 +3,17 @@ package slacknotifications.teamcity;
 public enum BuildStateEnum {
   BUILD_STARTED("buildStarted", "started"),
   BUILD_FINISHED("buildFinished", "finished"),
-  //BUILD_CHANGED_STATUS	("statusChanged", 			"changed status"),
+  BUILD_CHANGED_STATUS	("changedStatus", 			"changed status"),
   BEFORE_BUILD_FINISHED("beforeBuildFinish", "nearly finished"),
   RESPONSIBILITY_CHANGED("responsibilityChanged", "changed responsibility"),
   BUILD_INTERRUPTED("buildInterrupted", "been interrupted"),
   BUILD_SUCCESSFUL("buildSuccessful", "completed successfully"),
   BUILD_FAILED("buildFailed", "failed"),
   BUILD_FIXED("buildFixed", "been fixed"),
-  BUILD_BROKEN("buildBroken", "broken");
+  BUILD_BROKEN("buildBroken", "broken"),
+  BUILD_BROKE_MID("statusChanged", "broke mid"),
+  //Trigger when build broke while running and the previous run of the build was successful
+  BUILD_BROKE_MID_CHANGE("buildBrokeMidChange", "broke mid change");
 
   private final String shortName;
   private final String descriptionSuffix;

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/SlackNotificationPayloadManager.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/SlackNotificationPayloadManager.java
@@ -44,6 +44,11 @@ public class SlackNotificationPayloadManager {
     return content;
   }
 
+  public SlackNotificationPayloadContent statusChanged(SRunningBuild runningBuild, SFinishedBuild previousBuild){
+    SlackNotificationPayloadContent content = new SlackNotificationPayloadContent(server, runningBuild, previousBuild, BuildStateEnum.BUILD_CHANGED_STATUS);
+    return content;
+  }
+
   /**
    * Used by versions of TeamCity less than 7.0
    */

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
@@ -555,6 +555,13 @@ public class SlackNotificationConfig {
     return "";
   }
 
+  public String getStateBuildBrokeMidAsChecked() {
+    if (states.enabled(BUILD_BROKE_MID)) {
+      return "checked ";
+    }
+    return "";
+  }
+
   public Boolean isEnabledForAllBuildsInProject() {
     return allBuildTypesEnabled;
   }

--- a/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/BuildStateTest.java
+++ b/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/BuildStateTest.java
@@ -54,6 +54,7 @@ public class BuildStateTest {
     state.enable(BUILD_FINISHED);
     state.enable(BUILD_FAILED);
     state.enable(BUILD_SUCCESSFUL);
+    state.enable(BUILD_BROKE_MID);
     assertTrue(state.allEnabled());
   }
 
@@ -180,6 +181,7 @@ public class BuildStateTest {
     state.disable(BEFORE_BUILD_FINISHED);
     state.enable(BUILD_FINISHED);
     state.enable(BUILD_FAILED);
+    state.enable(BUILD_BROKE_MID);
     state.disable(BUILD_SUCCESSFUL);
     state.disable(BUILD_FIXED);
     state.disable(BUILD_BROKEN);

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageController.java
@@ -52,6 +52,9 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
   protected static final String BUILD_FIXED = "BuildFixed";
   protected static final String BUILD_FAILED = "BuildFailed";
   protected static final String BUILD_SUCCESSFUL = "BuildSuccessful";
+  protected static final String BUILD_BROKE_MID = "BuildBrokeMid";
+  protected static final String BUILD_BROKE_MID_CHANGE = "BuildBrokeMidChange";
+
 
 
   private final WebControllerManager myWebManager;
@@ -226,6 +229,8 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
                 checkAndAddBuildState(request, states, BuildStateEnum.BUILD_STARTED, BUILD_STARTED);
                 checkAndAddBuildState(request, states, BuildStateEnum.BUILD_INTERRUPTED, BUILD_INTERRUPTED);
                 checkAndAddBuildState(request, states, BuildStateEnum.BEFORE_BUILD_FINISHED, BEFORE_FINISHED);
+                checkAndAddBuildState(request, states, BuildStateEnum.BUILD_BROKE_MID, BUILD_BROKE_MID);
+                checkAndAddBuildState(request, states, BuildStateEnum.BUILD_BROKE_MID_CHANGE, BUILD_BROKE_MID_CHANGE);
                 checkAndAddBuildStateIfEitherSet(request, states, BuildStateEnum.BUILD_FINISHED, BUILD_SUCCESSFUL, BUILD_FAILED);
                 checkAndAddBuildState(request, states, BuildStateEnum.RESPONSIBILITY_CHANGED, "ResponsibilityChanged");
 

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/index.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/index.jsp
@@ -79,6 +79,13 @@
 				jQuerySlacknotification('.onBuildFailed').addClass('onCompletionDisabled');
 				jQuerySlacknotification('tr.onBuildFailed td input').attr('disabled', 'disabled');
 			}
+			if(jQuerySlacknotification('#buildBrokeMid').is(':checked')){
+                jQuerySlacknotification('.onBuildBrokeMid').removeClass('onCompletionDisabled');
+                jQuerySlacknotification('tr.onBuildBrokeMid td input').removeAttr('disabled');
+            } else {
+                jQuerySlacknotification('.onBuildBrokeMid').addClass('onCompletionDisabled');
+                jQuerySlacknotification('tr.onBuildBrokeMid td input').attr('disabled', 'disabled');
+            }
 		}
 
 		function toggleCustomContentEnabled(){

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
@@ -106,7 +106,7 @@
 													<td><label for="slackNotificationsEnabled">Enabled:</label></td>
 													<td style="padding-left:3px;" colspan=2><input id="slackNotificationsEnabled" type=checkbox name="slackNotificationsEnabled"/></td>
 												</tr>
-												<tr style="border:none;">
+													<tr style="border:none;">
 													<td>Trigger on Events:</td>
 													<td style="padding-left:3px;"><label style='white-space:nowrap;'>
 														<input onclick='selectBuildState();' class="buildState" id="buildStarted" name="BuildStarted"  type=checkbox />
@@ -127,31 +127,39 @@
 														 Build Responsibility Changed</label>
 													</td>
 												</tr>
-					
-												<tr style="border:none;" class="onCompletion"><td style="vertical-align:text-top; padding-top:0.33em;">On Completion:</td>
+												<tr style="border:none;" class="onCompletion"><td style="vertical-align:text-top; padding-top:0.33em;">When to send:</td>
 													<td colspan=2 >
 														<table style="padding:0; margin:0; left: 0px;"><tbody style="padding:0; margin:0; left: 0px;">
-																<tr style="padding:0; margin:0; left: 0px;"><td style="padding:0; margin:0; left: 0px;"><label style='white-space:nowrap;'>
-																	<input onclick='doExtraCompleted();' class="buildState" id="buildSuccessful" name="BuildSuccessful" type=checkbox />
-																	 Trigger when build is Successful</label>
-																	</td></tr>
-																<tr class="onBuildFixed" style="padding:0; margin:0; left: 0px;"><td style="padding:0; margin:0; padding-left: 2em; left: 0px;"><label style='white-space:nowrap;'>
-																	<input class="buildStateFixed" id="buildFixed" name="BuildFixed" type=checkbox />
-																	 Only trigger when build changes from Failure to Success</label>
-																	</td></tr>
-																<tr style="padding:0; margin:0; left: 0px;"><td style="padding:0; margin:0; left: 0px;"><label style='white-space:nowrap;'>
-																	<input onclick='doExtraCompleted();' class="buildState" id="buildFailed" name="BuildFailed" type=checkbox />
-																	 Trigger when build Fails</label>
-																	</td></tr>
-																<tr class="onBuildFailed" style="padding:0; margin:0; left: 0px;"><td style="padding:0; margin:0; padding-left: 2em; left: 0px;"><label style='white-space:nowrap;'>
-																	<input class="buildStateBroken" id="buildBroken" name="BuildBroken" type=checkbox />
-																	 Only trigger when build changes from Success to Failure</label>
-																	</td></tr>
+															<tr style="padding:0; margin:0; left: 0px;"><td style="padding:0; margin:0; left: 0px;"><label style='white-space:nowrap;'>
+																<input onclick='doExtraCompleted();' class="buildState" id="buildSuccessful" name="BuildSuccessful" type=checkbox />
+																 Trigger when build is Successful</label>
+																</td></tr>
+															<tr class="onBuildFixed" style="padding:0; margin:0; left: 0px;"><td style="padding:0; margin:0; padding-left: 2em; left: 0px;"><label style='white-space:nowrap;'>
+																<input class="buildStateFixed" id="buildFixed" name="BuildFixed" type=checkbox />
+																 Only trigger when build changes from Failure to Success</label>
+																</td></tr>
+															<tr style="padding:0; margin:0; left: 0px;"><td style="padding:0; margin:0; left: 0px;"><label style='white-space:nowrap;'>
+																<input onclick='doExtraCompleted();' class="buildState" id="buildFailed" name="BuildFailed" type=checkbox />
+																 Trigger when build Fails</label>
+																</td></tr>
+															<tr class="onBuildFailed" style="padding:0; margin:0; left: 0px;"><td style="padding:0; margin:0; padding-left: 2em; left: 0px;"><label style='white-space:nowrap;'>
+																<input class="buildStateBroken" id="buildBroken" name="BuildBroken" type=checkbox />
+																 Only trigger when build changes from Success to Failure</label>
+																</td></tr>
+															<tr style="padding:0; margin:0; left: 0px;"><td style="padding:0; margin:0; left: 0px;"><label style='white-space:nowrap;'>
+																<input onclick='doExtraCompleted();' class="buildState" id="buildBrokeMid" name="buildBrokeMid" type=checkbox />
+																 Trigger as soon as part of build fails</label>
+																</td></tr>
+															<tr class="onBuildFailed" style="padding:0; margin:0; left: 0px;"><td style="padding:0; margin:0; padding-left: 2em; left: 0px;"><label style='white-space:nowrap;'>
+                                                                <input class="buildStateBroken" id="buildBroken" name="BuildBroken" type=checkbox />
+                                                                 Only trigger when previous build was successful</label>
+                                                                </td></tr>
 														</tbody></table>
 													</td>
 												</tr>
+
 												<tr style="border:none;">
-													<td>Send or mention on first failure:</td>
+													<td>Send on first failure:</td>
 
 													<td><label style='white-space:nowrap;'>
                                                     	<input class="buildState" id="sendDefaultChannel" name="SendDefaultChannel" type=checkbox />
@@ -162,8 +170,10 @@
                                                         Send to recent commits</label>
                                                     </td>
 												</tr>
-												<tr style="border:none;"><td>&nbsp;</td>
-                                                    <td style="padding-left:3px;"><label style='white-space:nowrap;'>
+												<tr style="border:none;">
+												    <td>Mention on first failure:</td>
+
+                                                    <td><label style='white-space:nowrap;'>
 														<input class="buildState" id="mentionChannelEnabled" name="mentionChannelEnabled" type=checkbox />
 														 @channel</label>
 													</td>


### PR DESCRIPTION
Can be sent as soon as part of build fails every time or only when previous build was successful. Also modified getAttachments method to use separate lists to keep track of user and other commits.