### PR TITLE
Fix exception from null slackID, enable sending to channel when not specified

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
@@ -377,7 +377,7 @@ public class SlackNotificationImpl implements SlackNotification {
 
     // Separate user commits from other commits
     for(Commit commit : commits){
-      if (commit.getSlackUserId().equals(slackUser.substring(1))) {
+      if (commit.hasSlackUserId() && commit.getSlackUserId().equals(slackUser.substring(1))) {
         userCommits.add(commit);
       } else {
         otherCommits.add(commit);

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/BuildState.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/BuildState.java
@@ -138,7 +138,8 @@ public class BuildState {
   public boolean allEnabled() {
     boolean areAllEnbled = true;
     for (BuildStateEnum state : states.keySet()) {
-      if ((state.equals(BUILD_BROKEN) && states.get(BUILD_BROKEN).isEnabled()) || (state.equals(BUILD_FIXED) && states.get(BUILD_FIXED).isEnabled())) {
+      if ((state.equals(BUILD_BROKEN) && states.get(BUILD_BROKEN).isEnabled()) || (state.equals(BUILD_FIXED) && states.get(BUILD_FIXED).isEnabled())
+      || (state.equals(BUILD_BROKE_MID) && states.get(BUILD_BROKE_MID_CHANGE).isEnabled())) {
         return false;
       }
       if (state.equals(BUILD_BROKEN) || state.equals(BUILD_FIXED) || state.equals(BUILD_BROKE_MID_CHANGE)) {
@@ -156,6 +157,9 @@ public class BuildState {
         if (finishEnabled()) {
           enabled++;
         }
+      }
+      if (state.equals(BUILD_CHANGED_STATUS) && states.get(BUILD_BROKE_MID).isEnabled()) {
+        enabled++;
       }
       if (state.equals(BUILD_FINISHED) || state.equals(BUILD_BROKEN) || state.equals(BUILD_FIXED) || state.equals(BUILD_SUCCESSFUL) || state.equals(BUILD_FAILED) || state.equals(BUILD_BROKE_MID)) {
         continue;

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
@@ -477,6 +477,13 @@ public class SlackNotificationConfig {
           enabledStates += ", Build Successful";
         }
       }
+      if (states.enabled(BuildStateEnum.BUILD_BROKE_MID)) {
+        if (states.enabled(BuildStateEnum.BUILD_BROKE_MID_CHANGE)) {
+          enabledStates += ", Build Broke Mid Run";
+        } else {
+          enabledStates += ", Build Failed Mid Run";
+        }
+      }
       if (enabledStates.length() > 0) {
         return enabledStates.substring(1);
       } else {

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
@@ -118,8 +118,15 @@ public class SlackNotificationConfig {
       this.setMentionWhoTriggeredEnabled(Boolean.parseBoolean(e.getAttributeValue(WHO_TRIGGERED_ENABLED_MESSAGE)));
     }
 
+    /*
+    When updating to new version, sendDefaultChannel will not be in XML file, so this will enable sending to default
+    channel (which has always been behavior of older versions) until the checkbox is adjusted by the user.
+     */
     if (e.getAttribute(SEND_DEFAULT_CHANNEL) != null) {
       this.setSendDefaultChannel(Boolean.parseBoolean(e.getAttributeValue("sendDefaultChannel")));
+    }
+    else {
+      this.setSendDefaultChannel(true);
     }
 
     if (e.getAttribute(SEND_USERS) != null) {

--- a/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationConfigTest.java
+++ b/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationConfigTest.java
@@ -24,6 +24,7 @@ public class SlackNotificationConfigTest {
   SlackNotificationConfig slacknotificationMostEnabled;
   SlackNotificationConfig slacknotificationCustomContent;
   SlackNotificationConfig slacknotificationDMEnabledDefaultDisabled;
+  SlackNotificationConfig slacknotificationNoDMNoDefault;
 
 
   @Before
@@ -35,6 +36,8 @@ public class SlackNotificationConfigTest {
     slacknotificationMostEnabled = ConfigLoaderUtil.getFirstSlackNotificationInConfig(new File("src/test/resources/project-settings-test-all-but-respchange-states-enabled.xml"));
     slacknotificationCustomContent = ConfigLoaderUtil.getFirstSlackNotificationInConfig(new File("src/test/resources/project-settings-test-custom-content.xml"));
     slacknotificationDMEnabledDefaultDisabled = ConfigLoaderUtil.getFirstSlackNotificationInConfig(new File("src/test/resources/project-settings-send-DM-test.xml"));
+    slacknotificationNoDMNoDefault = ConfigLoaderUtil.getFirstSlackNotificationInConfig(new File("src/test/resources/project-settings-no-send-default-test.xml"));
+
   }
 
 //	private SlackNotificationConfig getFirstSlackNotificationInConfig(File f) throws JDOMException, IOException{
@@ -248,7 +251,12 @@ public class SlackNotificationConfigTest {
 
   @Test
   public void keepSendChannelWhenUpgradingTest() {
-    assertFalse(slacknotificationDMEnabledDefaultDisabled.getSendDefaultChannel());
+    assertTrue(slacknotificationNoDMNoDefault.getSendDefaultChannel());
+    assertFalse(slacknotificationNoDMNoDefault.getSendUsers());
   }
 
+  @Test
+  public void defaultChannelIsFalseTest() {
+    assertFalse(slacknotificationDMEnabledDefaultDisabled.getSendDefaultChannel());
+  }
 }

--- a/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationConfigTest.java
+++ b/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationConfigTest.java
@@ -246,4 +246,9 @@ public class SlackNotificationConfigTest {
     assertFalse(slacknotificationDMEnabledDefaultDisabled.getSendDefaultChannel());
   }
 
+  @Test
+  public void keepSendChannelWhenUpgradingTest() {
+    assertFalse(slacknotificationDMEnabledDefaultDisabled.getSendDefaultChannel());
+  }
+
 }

--- a/tcslackbuildnotifier-core/src/test/resources/project-settings-no-send-default-test.xml
+++ b/tcslackbuildnotifier-core/src/test/resources/project-settings-no-send-default-test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+    <slackNotifications enabled="true">
+        <slackNotification channel="#teamcity_slack_tests" token="https://hooks.slack."
+                           enabled="true" mention-channel-enabled="false"
+                           mention-slack-user-enabled="false" mention-here-enabled="true">
+            <states>
+                <state type="buildFixed" enabled="false"/>
+                <state type="buildInterrupted" enabled="true"/>
+                <state type="responsibilityChanged" enabled="false"/>
+                <state type="buildSuccessful" enabled="true"/>
+                <state type="buildStarted" enabled="false"/>
+                <state type="buildBroken" enabled="false"/>
+                <state type="beforeBuildFinish" enabled="false"/>
+                <state type="buildFailed" enabled="true"/>
+                <state type="buildFinished" enabled="true"/>
+            </states>
+            <build-types enabled-for-all="true" enabled-for-subprojects="true"/>
+        </slackNotification>
+    </slackNotifications>
+</settings>
+

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageController.java
@@ -232,6 +232,7 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
                 checkAndAddBuildState(request, states, BuildStateEnum.BUILD_BROKE_MID, BUILD_BROKE_MID);
                 checkAndAddBuildState(request, states, BuildStateEnum.BUILD_BROKE_MID_CHANGE, BUILD_BROKE_MID_CHANGE);
                 checkAndAddBuildStateIfEitherSet(request, states, BuildStateEnum.BUILD_FINISHED, BUILD_SUCCESSFUL, BUILD_FAILED);
+                checkAndAddBuildStateIfEitherSet(request, states, BuildStateEnum.BUILD_CHANGED_STATUS, BUILD_BROKE_MID, null);
                 checkAndAddBuildState(request, states, BuildStateEnum.RESPONSIBILITY_CHANGED, "ResponsibilityChanged");
 
                 if ((request.getParameter("buildTypeSubProjects") != null) && ("on".equalsIgnoreCase(request.getParameter("buildTypeSubProjects")))) {

--- a/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageControllerTest.java
+++ b/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageControllerTest.java
@@ -84,6 +84,9 @@ public class SlackNotificationAjaxEditPageControllerTest {
 
     checkAndAddBuildStateIfEitherSet(requestSuccessOnAndFailureOff, states, BuildStateEnum.BUILD_FINISHED, BUILD_SUCCESSFUL, BUILD_FAILED);
     assertTrue(states.enabled(BuildStateEnum.BUILD_FINISHED));
+
+    checkAndAddBuildStateIfEitherSet(requestSuccessOnAndFailureOff, states, BuildStateEnum.BUILD_CHANGED_STATUS, BUILD_BROKE_MID, null);
+    assertFalse(states.enabled(BuildStateEnum.BUILD_CHANGED_STATUS));
   }
 
   @Test

--- a/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/SlackNotificationDMTests.java
+++ b/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/SlackNotificationDMTests.java
@@ -214,5 +214,35 @@ public class SlackNotificationDMTests {
     assertNotNull(sendMock(true));
   }
 
+  @Test
+  public void allNullSlackIDTest() throws IOException {
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "Jimbo", null));
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "frankjh3", null));
+    controller.addCommitMockNotification(new Commit("jdajfla", "Did some stuff", "frankjh3", null));
+
+    assertNotNull(sendMock(true));
+  }
+
+  @Test
+  public void someNullSlackIDTest() throws IOException {
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "Jimbo", null));
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "Did some stuff", "someone", null));
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "frankjh3", "frankie.holzapfel"));
+    controller.addCommitMockNotification(new Commit("jdajfla", "Did some stuff", "someone", null));
+    controller.addCommitMockNotification(new Commit("jdajfla", "Did some stuff", "someone", null));
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "frankjh3", "frankie.holzapfel"));
+    assertNotNull(sendMock(true));
+  }
+
+  @Test
+  public void twoNullSlackIDTest() throws IOException {
+    controller.addCommitMockNotification(new Commit("abb23b4", "Merge of branch xyz", "Jimbo", null));
+    controller.addCommitMockNotification(new Commit("abb23b4", "commiting stuff from frankjh3", "frankjh3", null));
+
+    assertNotNull(sendMock(true));
+  }
+
 }
 


### PR DESCRIPTION
Also updated UI for which build events are enabled to include build broke mid run. Enabling sending to channel when not specified allows the notifications to function normally when upgraded to newer version.